### PR TITLE
【Fixe】rails gコマンド実行時に余計なファイルが生成されないように記述を追加

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,9 @@ Bundler.require(*Rails.groups)
 module RailsFriendApp
   class Application < Rails::Application
     config.load_defaults 6.1
-
   end
+  config.generators do |g|
+    g.assets false
+    g.helper false
+    end
 end


### PR DESCRIPTION
＃1

・config/application.rbに
```ruby
config.generators do |g|
  g.assets false
  g.helper false
end
``` 
を追加